### PR TITLE
확정된 예약 취소 로직 추가

### DIFF
--- a/src/main/java/business/HotelLounge.java
+++ b/src/main/java/business/HotelLounge.java
@@ -155,20 +155,26 @@ public class HotelLounge {
         while (true) {
             String inputReservationUuid = inputView.getReservationUuid();
             if (reservationMap.containsKey(inputReservationUuid)) {
-                reservationOutput.printCheckCancelReservation(
-                    reservationMap.get(inputReservationUuid), customer.getName());
-                int pick = inputView.getInputNumber(1, 2);
-                if (pick == 1) {
-                    reservationService.removeReservation(inputReservationUuid);
-                    reservationOutput.printCompleteCancelReservation(customer.getName());
-                    waitForThreeSec();
-                } else {
-                    reservationOutput.printReservationMaintained();
-                }
+                showCheckCancelReservationView(reservationMap, inputReservationUuid);
                 break;
             }
 
             reservationOutput.printNotFoundReservation();
+        }
+    }
+
+    private void showCheckCancelReservationView(
+        Map<String, Reservation> reservationMap, String inputReservationUuid) {
+        reservationOutput.printCheckCancelReservation(
+            reservationMap.get(inputReservationUuid), customer.getName());
+
+        int pick = inputView.getInputNumber(1, 2);
+        if (pick == 1) {
+            reservationService.removeReservation(inputReservationUuid);
+            reservationOutput.printCompleteCancelReservation(customer.getName());
+            waitForThreeSec();
+        } else {
+            reservationOutput.printReservationMaintained();
         }
     }
 

--- a/src/main/java/business/HotelLounge.java
+++ b/src/main/java/business/HotelLounge.java
@@ -2,11 +2,16 @@ package business;
 
 import domain.Customer;
 import domain.CustomerType;
+import domain.Reservation;
 import io.input.InputView;
 import io.output.BasketOutput;
 import io.output.OutputView;
+import io.output.ReservationOutput;
+import java.util.ArrayList;
+import java.util.Map;
 import service.BasketService;
 import service.CustomerService;
+import service.ReservationService;
 
 /**
  * 서비스 클래스 또는 InputView(사용자로부터의 입력)로부터 데이터를 요청받아서 OutputView 클래스로 보내주는 역할
@@ -18,6 +23,8 @@ public class HotelLounge {
     private final BasketOutput basketOutput = new BasketOutput();
     private final CustomerService customerService = new CustomerService();
     private final BasketService basketService = new BasketService();
+    private final ReservationService reservationService = new ReservationService();
+    private final ReservationOutput reservationOutput = new ReservationOutput();
 
     private Customer customer;
 
@@ -120,6 +127,9 @@ public class HotelLounge {
                 case 1:
 
                     break;
+                case 2:
+                    showCancelReservationView();
+                    break;
                 case 3: //장바구니 화면
                     showBasketView();
                     break;
@@ -130,6 +140,35 @@ public class HotelLounge {
                     flag = showLogoutView();
                     break;
             }
+        }
+    }
+
+    private void showCancelReservationView() {
+        Map<String, Reservation> reservationMap
+            = reservationService.getReservationMap(customer.getId());
+
+        if (!reservationOutput.printCancelReservationView(
+            new ArrayList<>(reservationMap.values()), customer.getName())) {
+            return;
+        }
+
+        while (true) {
+            String inputReservationUuid = inputView.getReservationUuid();
+            if (reservationMap.containsKey(inputReservationUuid)) {
+                reservationOutput.printCheckCancelReservation(
+                    reservationMap.get(inputReservationUuid), customer.getName());
+                int pick = inputView.getInputNumber(1, 2);
+                if (pick == 1) {
+                    reservationService.removeReservation(inputReservationUuid);
+                    reservationOutput.printCompleteCancelReservation(customer.getName());
+                    waitForThreeSec();
+                } else {
+                    reservationOutput.printReservationMaintained();
+                }
+                break;
+            }
+
+            reservationOutput.printNotFoundReservation();
         }
     }
 

--- a/src/main/java/business/HotelLounge.java
+++ b/src/main/java/business/HotelLounge.java
@@ -152,15 +152,12 @@ public class HotelLounge {
             return;
         }
 
-        while (true) {
-            String inputReservationUuid = inputView.getReservationUuid();
-            if (reservationMap.containsKey(inputReservationUuid)) {
-                showCheckCancelReservationView(reservationMap, inputReservationUuid);
-                break;
-            }
-
-            reservationOutput.printNotFoundReservation();
+        String inputReservationUuid = inputView.getReservationUuid();
+        if (reservationMap.containsKey(inputReservationUuid)) {
+            showCheckCancelReservationView(reservationMap, inputReservationUuid);
         }
+
+        reservationOutput.printNotFoundReservation();
     }
 
     private void showCheckCancelReservationView(

--- a/src/main/java/business/HotelLounge.java
+++ b/src/main/java/business/HotelLounge.java
@@ -155,9 +155,9 @@ public class HotelLounge {
         String inputReservationUuid = inputView.getReservationUuid();
         if (reservationMap.containsKey(inputReservationUuid)) {
             showCheckCancelReservationView(reservationMap, inputReservationUuid);
+        } else {
+            reservationOutput.printNotFoundReservation();
         }
-
-        reservationOutput.printNotFoundReservation();
     }
 
     private void showCheckCancelReservationView(

--- a/src/main/java/data/ReservationDatabase.java
+++ b/src/main/java/data/ReservationDatabase.java
@@ -1,13 +1,54 @@
 package data;
 
+import domain.Customer;
+import domain.CustomerType;
 import domain.Reservation;
+import domain.Room;
+import domain.RoomType;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class ReservationDatabase {
+
     private Map<String, Reservation> reservationMap = new HashMap<>();
 
-    public void addReservation(Reservation reservation){
+    public ReservationDatabase() {
+        // TODO DELETE
+        reservationMap.put("550e8400-e29b-41d4-a716-446655440000",
+            new Reservation("550e8400-e29b-41d4-a716-446655440000",
+                new Room(101, RoomType.LARGE, 10L, true),
+                new Customer("test1", "이종렬", "010-1234-5678", 1000000000L, CustomerType.CUSTOMER),
+                LocalDateTime.now()));
+        reservationMap.put("440e8400-e29b-41d4-a716-446655440000",
+            new Reservation("440e8400-e29b-41d4-a716-446655440000",
+                new Room(102, RoomType.SWEET, 20L, true),
+                new Customer("test1", "이종렬", "010-1234-5678", 1000000000L, CustomerType.CUSTOMER),
+                LocalDateTime.now()));
+        reservationMap.put("330e8400-e29b-41d4-a716-446655440000",
+            new Reservation("330e8400-e29b-41d4-a716-446655440000",
+                new Room(103, RoomType.SPECIAL, 40L, true),
+                new Customer("test1", "이종렬", "010-1234-5678", 1000000000L, CustomerType.CUSTOMER),
+                LocalDateTime.now()));
+        reservationMap.put("220e8400-e29b-41d4-a716-446655440000",
+            new Reservation("220e8400-e29b-41d4-a716-446655440000",
+                new Room(104, RoomType.LOVE, 30L, true),
+                new Customer("test1", "이종렬", "010-1234-5678", 1000000000L, CustomerType.CUSTOMER),
+                LocalDateTime.now()));
+    }
+
+    public void addReservation(Reservation reservation) {
         reservationMap.put(reservation.getUuid(), reservation);
+    }
+
+    public Map<String, Reservation> getReservationMap(String customerId) {
+        return reservationMap.entrySet().stream()
+            .filter(entry -> entry.getValue().getCustomer().getId().equals(customerId))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public void removeReservation(String uuid) {
+        reservationMap.remove(uuid);
     }
 }

--- a/src/main/java/domain/Reservation.java
+++ b/src/main/java/domain/Reservation.java
@@ -3,6 +3,7 @@ package domain;
 import java.time.LocalDateTime;
 
 public class Reservation {
+
     private String uuid;
     private Room room;
     private Customer customer;
@@ -23,7 +24,7 @@ public class Reservation {
         return room;
     }
 
-    public Customer getCustomerId() {
+    public Customer getCustomer() {
         return customer;
     }
 

--- a/src/main/java/io/input/InputView.java
+++ b/src/main/java/io/input/InputView.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 public class InputView {
 
     private final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private final String REGEX_UUID = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$";
     private StringTokenizer st;
 
     public int getInputNumber(int start, int from) {
@@ -71,6 +72,22 @@ public class InputView {
                 String input = br.readLine();
 
                 if (!Pattern.matches("^\\d{3}-\\d{3,4}-\\d{4}$", input)) {
+                    throw new IllegalArgumentException();
+                }
+
+                return input;
+            } catch (Exception e) {
+                System.out.println("입력이 잘못되었습니다.");
+            }
+        }
+    }
+
+    public String getReservationUuid() {
+        while (true) {
+            try {
+                String input = br.readLine();
+
+                if (!Pattern.matches(REGEX_UUID, input)) {
                     throw new IllegalArgumentException();
                 }
 

--- a/src/main/java/io/output/ReservationOutput.java
+++ b/src/main/java/io/output/ReservationOutput.java
@@ -13,7 +13,7 @@ public class ReservationOutput {
     private final String LIST_EMPTY = "현재 확정된 예약이 없습니다. 메인 화면으로 이동합니다.";
     private final String RESERVATION_NUMBER = "예약번호: ";
     private final String CHECK_CANCEL_RESERVATION = "예약을 취소하시겠습니까?\n1. 확인\t2. 취소";
-    private final String NOT_FOUND_RESERVATION = "입력하신 예약 번호에 맞는 예약이 없습니다. 다시 입력해주세요.";
+    private final String NOT_FOUND_RESERVATION = "입력하신 예약 번호에 맞는 예약이 없습니다. 메인 화면으로 이동합니다.";
     private final String COMPLETE_CANCEL_RESERVATION = "예약이 성공적으로 취소되었습니다.";
     private final String RESERVATION_MAINTAINED = "취소를 선택하셨습니다. 예약은 취소되지 않습니다.";
 

--- a/src/main/java/io/output/ReservationOutput.java
+++ b/src/main/java/io/output/ReservationOutput.java
@@ -1,0 +1,57 @@
+package io.output;
+
+import domain.Reservation;
+import java.util.List;
+
+public class ReservationOutput {
+
+    private final String TAB = "\t|\t";
+    private final String TITLE_PREFIX = "[ 뇌정지 호텔 - ";
+    private final String TITLE_SUFFIX = "님 ]\n";
+
+    private final String SELECT_CANCEL = "\n취소하실 예약 번호를 입력해주세요: (예약번호 입력 후 엔터)";
+    private final String LIST_EMPTY = "현재 확정된 예약이 없습니다. 메인 화면으로 이동합니다.";
+    private final String RESERVATION_NUMBER = "예약번호: ";
+    private final String CHECK_CANCEL_RESERVATION = "예약을 취소하시겠습니까?\n1. 확인\t2. 취소";
+    private final String NOT_FOUND_RESERVATION = "입력하신 예약 번호에 맞는 예약이 없습니다. 다시 입력해주세요.";
+    private final String COMPLETE_CANCEL_RESERVATION = "예약이 성공적으로 취소되었습니다.";
+    private final String RESERVATION_MAINTAINED = "취소를 선택하셨습니다. 예약은 취소되지 않습니다.";
+
+    public boolean printCancelReservationView(List<Reservation> reservationList, String name) {
+        System.out.println(TITLE_PREFIX + name + TITLE_SUFFIX);
+        if (reservationList == null || reservationList.isEmpty()) {
+            System.out.println(LIST_EMPTY);
+            return false;
+        }
+
+        reservationList.forEach(reservation -> {
+            System.out.println(
+                reservation.getRoom().getNumber() + TAB + reservation.getRoom().getRoomType() + TAB
+                    + reservation.getRoom().getCost() + TAB + reservation.getUuid());
+        });
+        System.out.println(SELECT_CANCEL);
+        return true;
+    }
+
+    public void printCheckCancelReservation(Reservation reservation, String name) {
+        System.out.println(TITLE_PREFIX + name + TITLE_SUFFIX);
+        System.out.println(
+            RESERVATION_NUMBER + reservation.getUuid() + "(\"" + reservation.getRoom().getNumber()
+                + TAB + reservation.getRoom().getRoomType() + TAB + reservation.getRoom().getCost()
+                + "\")\n");
+        System.out.println(CHECK_CANCEL_RESERVATION);
+    }
+
+    public void printNotFoundReservation() {
+        System.out.println(NOT_FOUND_RESERVATION);
+    }
+
+    public void printCompleteCancelReservation(String name) {
+        System.out.println(TITLE_PREFIX + name + TITLE_SUFFIX);
+        System.out.println(COMPLETE_CANCEL_RESERVATION);
+    }
+
+    public void printReservationMaintained() {
+        System.out.println(RESERVATION_MAINTAINED);
+    }
+}

--- a/src/main/java/service/ReservationService.java
+++ b/src/main/java/service/ReservationService.java
@@ -1,7 +1,21 @@
 package service;
 
+import data.ReservationDatabase;
+import domain.Reservation;
+import java.util.Map;
+
 /**
  * 예약에 관련된 로직
  */
 public class ReservationService {
+
+    private final ReservationDatabase reservationDatabase = new ReservationDatabase();
+
+    public Map<String, Reservation> getReservationMap(String customerId) {
+        return reservationDatabase.getReservationMap(customerId);
+    }
+
+    public void removeReservation(String uuid) {
+        reservationDatabase.removeReservation(uuid);
+    }
 }


### PR DESCRIPTION
1. 고객 로그인 화면에서 2번 (객실 예약 취소) 선택 시 예약 취소 화면으로 이동합니다.
2. 로그인한 고객이 확정한 예약 리스트를 출력하고 삭제할 예약의 uuid를 입력 받습니다.
   + 예약 리스트가 비어있다면 함수를 종료하고 메인 화면으로 이동합니다.
   + uuid 정규식에 맞지 않는 입력은 예외처리합니다.
3. uuid에 맞는 예약을 찾아서 예약 취소 확인 화면으로 이동합니다.
   + uuid에 맞는 예약을 찾지 못한다면 메인 화면으로 이동합니다.
4. 1번 선택 시 해당 예약을 제거하고 3초 후 메인 화면으로 이동합니다.
5. 2번 선택 시 메인 화면으로 이동합니다.
